### PR TITLE
Various Updates to Connection Service in Core Services Package

### DIFF
--- a/packages/core-services/src/connection-service.ts
+++ b/packages/core-services/src/connection-service.ts
@@ -12,6 +12,7 @@ export default function init (options: ServiceOptions) {
 export class ServiceClass extends BaseServiceClass {
 	public connections!: any;
 	public connectionId!: any;
+	public memberId!: any;
 	public client!: any;
 	public defaultOptions!: any;
 	public options!: any;
@@ -22,6 +23,7 @@ export class ServiceClass extends BaseServiceClass {
 		}
 		this.client = options.client
 		this.connectionId = options.connectionId || this.generateId()
+		this.memberId = this.generateId()
 		this.defaultOptions = options.defaultOptions || {}
 		this.connectionServiceCheck().then(() => {
 			this.connect(options)
@@ -50,7 +52,8 @@ export class ServiceClass extends BaseServiceClass {
 				client,
 				connectionType: this.getConnectionType(),
 				serviceTypes: [this.getServiceType()],
-				status: 'pending'
+				status: 'pending',
+				members: [this.memberId]
 			}
 			return this.connections.create(connection)
 		}))

--- a/packages/core-services/src/connection-service.ts
+++ b/packages/core-services/src/connection-service.ts
@@ -121,7 +121,7 @@ export class ServiceClass extends BaseServiceClass {
 				debug(
 					`no connection service found on application setup. ${this.getConnectionType()} service will create connection service.`
 				)
-				app.use('connections', BaseService({id: 'id'}))
+				app.use('connections', BaseService({id: 'connectionId'}))
 			}
 			this.connections = app.service('connections')
 			return resolve(this.connections)

--- a/packages/core-services/src/connection-service.ts
+++ b/packages/core-services/src/connection-service.ts
@@ -112,13 +112,16 @@ export class ServiceClass extends BaseServiceClass {
 	}
 	private connectionServiceCheck (app: any): any {
 		return new Promise(resolve => {
+			if (this.options.connectionService) {
+				debug(`using provided connection service as internal service`)
+				this.connections = this.options.connectionService
+				return resolve(this.connections)
+			}
 			if (typeof app.service('connection') === 'undefined') {
-				debug(`no connection service found on provided application.
-					${this.getConnectionType()} service will create connection service.`
+				debug(
+					`no connection service found on application setup. ${this.getConnectionType()} service will create connection service.`
 				)
 				app.use('connections', BaseService({id: 'id'}))
-				this.connections = app.service('connections')
-				return resolve(this.connections)
 			}
 			this.connections = app.service('connections')
 			return resolve(this.connections)

--- a/packages/core-services/src/connection-service.ts
+++ b/packages/core-services/src/connection-service.ts
@@ -50,7 +50,7 @@ export class ServiceClass extends BaseServiceClass {
 		const service = connections || this.connections
 		return this.getInfo().then(((info: any) => {
 			const connection = {
-				id,
+				[service._id]: id,
 				info,
 				client,
 				connectionType: this.getConnectionType(),

--- a/packages/core-services/src/connection-service.ts
+++ b/packages/core-services/src/connection-service.ts
@@ -113,6 +113,17 @@ export class ServiceClass extends BaseServiceClass {
 	private connectionServiceCheck (app: any): any {
 		return new Promise(resolve => {
 			if (this.options.connectionService) {
+				if (typeof this.options.connectionService === 'string') {
+					if (typeof app.service(this.options.connectionService) === 'undefined') {
+						debug(
+							`no service ${this.options.connectionService} found on application setup. 
+							${this.getConnectionType()} service will create ${this.options.connectionService} service.`
+						)
+						app.use(this.options.connectionService, BaseService({id: `${this.options.connectionService}Id`}))
+					}
+					this.connections = app.service(this.options.connectionService)
+					return resolve(this.connections)
+				}
 				debug(`using provided connection service as internal service`)
 				this.connections = this.options.connectionService
 				return resolve(this.connections)

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -3,6 +3,7 @@ import feathers from '@feathersjs/feathers';
 import { v4 as uuid } from 'uuid'
 import { default as Debug } from 'debug'
 
+import { default as BaseService } from '../src/base-service'
 import { default as ConnectionService, ServiceClass } from '../src/connection-service'
 
 const debug = Debug('feathers-service-manager:core-services:base-service:tests')
@@ -26,9 +27,11 @@ describe('feathers-service-manager:connection-service', () => {
 		events: ['testing']
 	}
 
-	const optionsCustom = {
+	app.use('internal', BaseService({ events:['events'] }))
+	const optionsProvidedService = {
 		connectionId: uuid(),
 		client: {},
+		connectionService: app.service('provided-service'),
 		events: ['testing']
 	}
 
@@ -44,11 +47,19 @@ describe('feathers-service-manager:connection-service', () => {
 	describe('Initialization', () => {
 		describe('setup', () => {
 			describe('internal connection service', () => {
-				describe('connection service does not exist on app at initialization', () => {
+				describe('connection service does not exist on app at setup', () => {
 					it('creates internal connection service', () => {
-						setupApp.use('conns', ConnectionService(options))
-						const createdService = setupApp.service('connections')
-						expect(createdService).to.not.equal(undefined)
+						const rawService = new ServiceClass(options)
+						rawService.setup(app, '/internal-service-test')
+						expect(app.service('connections')).to.not.equal(undefined)
+						expect(rawService.connections.path).to.equal('connections')
+					})
+				})
+				describe('connection service provided in service options', () => {
+					it('uses the provided service as the internal connection service', () => {
+						const rawService = new ServiceClass(optionsProvidedService)
+						rawService.setup(app, '/internal-provided-test')
+						expect(rawService.connections.path).to.equal('internal')
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -48,18 +48,18 @@ describe('feathers-service-manager:connection-service', () => {
 		describe('setup', () => {
 			describe('internal connection service', () => {
 				describe('connection service does not exist on app at setup', () => {
+					const rawService = new ServiceClass(options)
+					rawService.setup(setupApp, '/internal-service-test')
 					it('creates internal connection service', () => {
-						const rawService = new ServiceClass(options)
-						rawService.setup(app, '/internal-service-test')
-						expect(app.service('connections')).to.not.equal(undefined)
-						expect(rawService.connections.path).to.equal('connections')
+						expect(setupApp.service('connections')).to.not.equal(undefined)
+						expect(rawService.connections).to.equal('connections')
 					})
 				})
 				describe('connection service provided in service options', () => {
+					const rawService = new ServiceClass(optionsProvidedService)
+					rawService.setup(setupApp, '/internal-service-provided-test')
 					it('uses the provided service as the internal connection service', () => {
-						const rawService = new ServiceClass(optionsProvidedService)
-						rawService.setup(app, '/internal-provided-test')
-						expect(rawService.connections.path).to.equal('internal')
+						expect(rawService.connections).to.not.equal(undefined)
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -98,7 +98,7 @@ describe('feathers-service-manager:connection-service', () => {
 		describe('createConnection', () => {
 			it('adds a connection to the connection store and returns the original connection data', () => {
 				return rawService.createConnection(connId, 'client').then((result: any) => {
-					expect(result.id).to.equal(connId)
+					expect(result.connectionId).to.equal(connId)
 					expect(result.client).to.equal('client')
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -26,6 +26,12 @@ describe('feathers-service-manager:connection-service', () => {
 		events: ['testing']
 	}
 
+	const optionsCustom = {
+		connectionId: uuid(),
+		client: {},
+		events: ['testing']
+	}
+
 	app.use('conns', ConnectionService(options))
 	app.use('conns-missing-connectionId', ConnectionService(missingConnectionId))
 
@@ -42,7 +48,7 @@ describe('feathers-service-manager:connection-service', () => {
 					it('creates internal connection service', () => {
 						setupApp.use('conns', ConnectionService(options))
 						const createdService = setupApp.service('connections')
-						expect(createdService).to.not.equal('undefined')
+						expect(createdService).to.not.equal(undefined)
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -107,7 +107,7 @@ describe('feathers-service-manager:connection-service', () => {
 		describe('getConnection', () => {
 			it('returns a connection from the connection store', () => {
 				return rawService.getConnection(connId).then((result: any) => {
-					expect(result.id).to.equal(connId)
+					expect(result.connectionIdd).to.equal(connId)
 					expect(result.client).to.equal('client')
 				})
 			})
@@ -115,11 +115,11 @@ describe('feathers-service-manager:connection-service', () => {
 
 		describe('updateConnection', () => {
 			it('updates an existing connection with provided data', () => {
-				return rawService.getConnection(connId).then((results: any) => {
-					return rawService.updateConnection(connId, {...results, status: 'ok'})
-					.then((final: any) => {
-						expect(final.id).to.equal(connId)
-						expect(final.status).to.equal('ok')
+				return rawService.getConnection(connId).then((toUpdate: any) => {
+					return rawService.updateConnection(connId, {...toUpdate, status: 'ok'})
+					.then((result: any) => {
+						expect(result.connectionId).to.equal(connId)
+						expect(result.status).to.equal('ok')
 					})
 				})
 			})
@@ -127,11 +127,11 @@ describe('feathers-service-manager:connection-service', () => {
 
 		describe('patchConnection', () => {
 			it('patches an existing connection with provided data', () => {
-				return rawService.getConnection(connId).then((results: any) => {
-					return rawService.patchConnection(connId, {...results, status: 'ok'})
-					.then((final: any) => {
-						expect(final.id).to.equal(connId)
-						expect(final.status).to.equal('ok')
+				return rawService.getConnection(connId).then((toPatch: any) => {
+					return rawService.patchConnection(connId, {...toPatch, status: 'ok'})
+					.then((result: any) => {
+						expect(result.connectionId).to.equal(connId)
+						expect(result.status).to.equal('ok')
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -107,7 +107,7 @@ describe('feathers-service-manager:connection-service', () => {
 		describe('getConnection', () => {
 			it('returns a connection from the connection store', () => {
 				return rawService.getConnection(connId).then((result: any) => {
-					expect(result.connectionIdd).to.equal(connId)
+					expect(result.connectionId).to.equal(connId)
 					expect(result.client).to.equal('client')
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -137,6 +137,14 @@ describe('feathers-service-manager:connection-service', () => {
 			})
 		})
 
+		describe('removeConnection', () => {
+			it('removes a connection from the connection store and returns the removed connection', (() => {
+				return rawService.removeConnection(options.connectionId).then((result: any) => {
+					expect(result.connectionId).to.equal(options.connectionId)
+				})
+			}))
+		})
+
 		describe('getConnectionId', () => {
 			it(`returns the current service's connectionId`, () => {
 				expect(rawService.getConnectionId()).to.equal(options.connectionId)
@@ -177,14 +185,6 @@ describe('feathers-service-manager:connection-service', () => {
 					expect(result).to.equal('nan')
 				})
 			})
-		})
-
-		describe('removeConnection', () => {
-			it('removes a connection from the connection store and returns the removed connection', (() => {
-				return rawService.removeConnection(options.connectionId).then((result: any) => {
-					expect(result.id).to.equal(options.connectionId)
-				})
-			}))
 		})
 	})
 	// describe('Common Service Tests', () => {

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -50,16 +50,19 @@ describe('feathers-service-manager:connection-service', () => {
 				describe('connection service does not exist on app at setup', () => {
 					const rawService = new ServiceClass(options)
 					rawService.setup(setupApp, '/internal-service-test')
-					it('creates internal connection service', () => {
+					it('adds connection service to application', () => {
 						expect(setupApp.service('connections')).to.not.equal(undefined)
-						expect(rawService.connections).to.equal('connections')
+					})
+					it('uses the created service as internal connection service', () => {
+						expect(rawService.connections instanceof BaseService).to.be.true
+						expect(rawService.connections.id).to.equal('connectionId')
 					})
 				})
 				describe('connection service provided in service options', () => {
 					const rawService = new ServiceClass(optionsProvidedService)
 					rawService.setup(setupApp, '/internal-service-provided-test')
 					it('uses the provided service as the internal connection service', () => {
-						expect(rawService.connections).to.not.equal(undefined)
+						expect(rawService.connections.id).to.not.equal('connectionId')
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -27,11 +27,14 @@ describe('feathers-service-manager:connection-service', () => {
 		events: ['testing']
 	}
 
-	app.use('internal', BaseService({ events:['events'] }))
+	setupApp.use('internal', BaseService({
+		id: 'internalId',
+		events:['events']
+	}))
 	const optionsProvidedService = {
 		connectionId: uuid(),
 		client: {},
-		connectionService: app.service('provided-service'),
+		connectionService: setupApp.service('internal'),
 		events: ['testing']
 	}
 
@@ -54,15 +57,14 @@ describe('feathers-service-manager:connection-service', () => {
 						expect(setupApp.service('connections')).to.not.equal(undefined)
 					})
 					it('uses the created service as internal connection service', () => {
-						expect(rawService.connections instanceof BaseService).to.be.true
-						expect(rawService.connections.id).to.equal('connectionId')
+						expect(rawService.connections._id).to.equal('connectionId')
 					})
 				})
 				describe('connection service provided in service options', () => {
 					const rawService = new ServiceClass(optionsProvidedService)
 					rawService.setup(setupApp, '/internal-service-provided-test')
 					it('uses the provided service as the internal connection service', () => {
-						expect(rawService.connections.id).to.not.equal('connectionId')
+						expect(rawService.connections._id).to.equal('internalId')
 					})
 				})
 			})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -70,7 +70,7 @@ describe('feathers-service-manager:connection-service', () => {
 							expect(setupApp.service('connections')).to.not.equal(undefined)
 						})
 					})
-					it('uses the service as internal connection service', () => {
+					it(`uses the 'connections' service as internal connection service`, () => {
 						expect(rawService.connections._id).to.equal('connectionId')
 					})
 				})
@@ -83,7 +83,7 @@ describe('feathers-service-manager:connection-service', () => {
 								expect(setupApp.service('stringService')).to.not.equal(undefined)
 							})
 						})
-						it('uses the service as internal connection service', () => {
+						it('uses the provided service as internal connection service', () => {
 							expect(rawService.connections._id).to.equal('stringServiceId')
 						})
 					})

--- a/packages/core-services/test/connection-service.test.ts
+++ b/packages/core-services/test/connection-service.test.ts
@@ -31,10 +31,22 @@ describe('feathers-service-manager:connection-service', () => {
 		id: 'internalId',
 		events:['events']
 	}))
-	const optionsProvidedService = {
+	const optionsServiceProvided = {
 		connectionId: uuid(),
 		client: {},
 		connectionService: setupApp.service('internal'),
+		events: ['testing']
+	}
+	const optionsServiceStringProvided = {
+		connectionId: uuid(),
+		client: {},
+		connectionService: 'stringService',
+		events: ['testing']
+	}
+	const optionsServiceStringProvidedExists = {
+		connectionId: uuid(),
+		client: {},
+		connectionService: 'internal',
 		events: ['testing']
 	}
 
@@ -50,21 +62,37 @@ describe('feathers-service-manager:connection-service', () => {
 	describe('Initialization', () => {
 		describe('setup', () => {
 			describe('internal connection service', () => {
-				describe('connection service does not exist on app at setup', () => {
+				describe('connectionService option not provided', () => {
 					const rawService = new ServiceClass(options)
 					rawService.setup(setupApp, '/internal-service-test')
-					it('adds connection service to application', () => {
-						expect(setupApp.service('connections')).to.not.equal(undefined)
+					describe('connection service does not exist on app at setup', () => {
+						it('adds connection service to application', () => {
+							expect(setupApp.service('connections')).to.not.equal(undefined)
+						})
 					})
-					it('uses the created service as internal connection service', () => {
+					it('uses the service as internal connection service', () => {
 						expect(rawService.connections._id).to.equal('connectionId')
 					})
 				})
-				describe('connection service provided in service options', () => {
-					const rawService = new ServiceClass(optionsProvidedService)
-					rawService.setup(setupApp, '/internal-service-provided-test')
-					it('uses the provided service as the internal connection service', () => {
-						expect(rawService.connections._id).to.equal('internalId')
+				describe('connectionService option provided', () => {
+					describe('string provided as connectionService option', () => {
+						const rawService = new ServiceClass(optionsServiceStringProvided)
+						rawService.setup(setupApp, '/internal-service-string-provided-test')
+						describe('provided service does not exist on app at setup', () => {
+							it('adds connection service to application', () => {
+								expect(setupApp.service('stringService')).to.not.equal(undefined)
+							})
+						})
+						it('uses the service as internal connection service', () => {
+							expect(rawService.connections._id).to.equal('stringServiceId')
+						})
+					})
+					describe('service instance provided as connectionService option', () => {
+						const rawService = new ServiceClass(optionsServiceProvided)
+						rawService.setup(setupApp, '/internal-service-provided-test')
+						it('uses the provided service as the internal connection service', () => {
+							expect(rawService.connections._id).to.equal('internalId')
+						})
 					})
 				})
 			})


### PR DESCRIPTION
**connectionService option**

- Adds the ability to pass a existing feathers service or service name for use as internal connection service

**memberId property**

- Sets the memberId property to identify service when multiple services using the same connection client
